### PR TITLE
sync version on package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6064,7 +6064,7 @@
     },
     "packages/ii-login-button": {
       "name": "@dfinity/ii-login-button",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "dependencies": {
         "assert": "^2.0.0",
         "bip39": "^3.0.4",


### PR DESCRIPTION
On latest merged PR (of last week), you bumped the version, but on the "root" package-lock the npm install was not run.

I did it today and had that update. It's just chore, but rather have it not mixed up with other PRs.