### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   linter:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
         with:
           node-version: 18
       - run: npm clean-install


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v2` -> `actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0`
  - Version: v2.7.0 | Latest: v6.0.2 | Release age: 88d
  - Commit: https://github.com/actions/checkout/commit/ee0669bd1cc54295c223e0bb666b733df41de1c5

- `actions/setup-node@v1` -> `actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6`
  - Version: v1.4.6 | Latest: v6.3.0 | Release age: 35d
  - Commit: https://github.com/actions/setup-node/commit/f1f314fca9dfce2769ece7d933488f076716723e


### Files modified

- `.github/workflows/ci.yml`